### PR TITLE
chore: update event date in config

### DIFF
--- a/_config.yml
+++ b/_config.yml
@@ -16,7 +16,7 @@ markdown: kramdown
 goal: $15,000
 
 ### content configuration ###
-title:       "St. John's 24-hour Charity Stream Event (11/2/24)"
+title:       "St. John's 24-hour Charity Stream Event (11/8/25)"
 keywords:    "twitch, extra-life, charity, ucsf benioff, marathon"
 description: "24-hour Charity Stream Event to raise money for UCSF Benioff Children's Hospital hosted by St. John Johnson"
 source_link: "https://github.com/stjohnjohnson/stj.watch"


### PR DESCRIPTION
## Summary
- update site title to use 11/8/25 event date
- verified no other dates required changes

## Testing
- `bundle install`
- `bundle exec jekyll build`


------
https://chatgpt.com/codex/tasks/task_e_689197455b30832390dbfba9c52489fb