### PR TITLE
Add Makefile for local Jekyll development

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,0 +1,15 @@
+.RECIPEPREFIX := >
+
+.PHONY: update install serve build
+
+update:
+>bundle update
+
+install:
+>bundle install
+
+serve:
+>bundle exec jekyll serve --host 0.0.0.0
+
+build:
+>bundle exec jekyll build


### PR DESCRIPTION
## Summary
- add a Makefile with targets for updating, installing, building, and serving the site

## Testing
- `bundle install`
- `make build`


------
https://chatgpt.com/codex/tasks/task_e_68b51bc8c7088323be198e3473571e97