### PR TITLE
Set 2026 stream to 25 hours and normalize 2025 fundraising total

### DIFF
--- a/_config.yml
+++ b/_config.yml
@@ -16,7 +16,7 @@ markdown: kramdown
 goal: $25,000
 
 ### content configuration ###
-title:       "St. John's 24-hour Charity Stream Event (11/1/25)"
+title:       "St. John's 24-hour Charity Stream Event (11/7/26)"
 keywords:    "twitch, extra-life, charity, ucsf benioff, marathon"
 description: "24-hour Charity Stream Event to raise money for UCSF Benioff Children's Hospital hosted by St. John Johnson"
 source_link: "https://github.com/stjohnjohnson/stj.watch"

--- a/_config.yml
+++ b/_config.yml
@@ -13,7 +13,7 @@ lsi: false
 markdown: kramdown
 
 ### target values
-goal: $20,000
+goal: $25,000
 
 ### content configuration ###
 title:       "St. John's 24-hour Charity Stream Event (11/1/25)"

--- a/_posts/2000-01-01-what.md
+++ b/_posts/2000-01-01-what.md
@@ -21,11 +21,10 @@ style: center
 
 <div class="clear"></div>
 
-#### On **November 1st** I'll be running another charity event to raise money for the [**UCSF Benioff Children's Hospitals**](https://give.ucsfbenioffchildrens.org) via Extra-Life. I will be streaming on Twitch for **24 hours straight** playing games with friends, family, and **YOU.**
+#### On **November 7th, 2026** I'll be running another charity event to raise money for the [**UCSF Benioff Children's Hospitals**](https://give.ucsfbenioffchildrens.org) via Extra-Life. I will be streaming on Twitch for **25 hours** playing games with friends, family, and **YOU.**
 
-#### Last year, you helped me raise over **$21,841** for the children through this event.  This year, more than ever, the children need our help.  Click the [**donate button**](https://stj.watch/donate) above and help us push past our **goal of {{ site.goal }}**.
+#### Last year, you helped me raise over **$26,724** for the children through this event.  This year, more than ever, the children need our help.  Click the [**donate button**](https://stj.watch/donate) above and help us push past our **goal of {{ site.goal }}**.
 
-#### If you're unable to donate, please [**watch the stream,**](https://stream.stj.watch/) say hello, chat, and encourage me when I'm **_completely exhausted_** at the 23 hour mark.
+#### If you're unable to donate, please [**watch the stream,**](https://stream.stj.watch/) say hello, chat, and encourage me when I'm **_completely exhausted_** near the 24 hour mark.
 
 <canvas id="flyingspace"></canvas>
-

--- a/_posts/2000-01-02-who.md
+++ b/_posts/2000-01-02-who.md
@@ -35,30 +35,34 @@ fa-icon: user-astronaut
 
 --------------------------
 
-### Thanks to the incredible generosity of friends and family, my annual charity streams have raised **over $58,000 for children in need!**
+### Thanks to the incredible generosity of friends and family, my annual charity streams have raised **over $86,000 for children in need!**
 
 <div style="margin: 3em 0;"></div>
 
 <div class="fundraising-chart">
-    <div class="bar" style="height:22%">
+    <div class="bar" style="height:18%">
         <span class="amount">$4,752</span>
         <span class="year">2020</span>
     </div>
-    <div class="bar" style="height:33%">
+    <div class="bar" style="height:27%">
         <span class="amount">$7,116</span>
         <span class="year">2021</span>
     </div>
-    <div class="bar" style="height:44%">
+    <div class="bar" style="height:36%">
         <span class="amount">$9,660</span>
         <span class="year">2022</span>
     </div>
-    <div class="bar" style="height:75%">
+    <div class="bar" style="height:61%">
         <span class="amount">$16,336</span>
         <span class="year">2023</span>
     </div>
-    <div class="bar" style="height:100%">
+    <div class="bar" style="height:82%">
         <span class="amount">$21,841</span>
         <span class="year">2024</span>
+    </div>
+    <div class="bar" style="height:100%">
+        <span class="amount">$26,724</span>
+        <span class="year">2025</span>
     </div>
 </div>
 

--- a/_posts/2000-01-04-when.md
+++ b/_posts/2000-01-04-when.md
@@ -6,9 +6,9 @@ style: center
 fa-icon: calendar-day
 ---
 
-### Stream starts at [**9:30am PT** on **November 1st**](https://time.is/0930AM_1_Nov_2025_in_PT/ET/CT/MT/GMT)
+### Stream starts at [**8:30am PT** on **November 7th**](https://time.is/0830AM_7_Nov_2026_in_PT/ET/CT/MT/GMT)
 
-#### It will end **24 hours later** at [9:30am PT on November 2nd](https://time.is/0930AM_2_Nov_2025_in_PT/ET/CT/MT/GMT)
+#### It will end **25 hours later** at [9:30am PT on November 8th](https://time.is/0930AM_8_Nov_2026_in_PT/ET/CT/MT/GMT)
 
 #### To stay healthy, I will be taking **5-10 min** breaks every **few hours**
 

--- a/_redirect/donate.md
+++ b/_redirect/donate.md
@@ -1,4 +1,4 @@
 ---
-target: https://www.extra-life.org/index.cfm?fuseaction=donordrive.participant&participantID=548692#donate
+target: https://www.extra-life.org/index.cfm?fuseaction=donordrive.participant&participantID=565756#donate
 layout: redirect
 ---

--- a/js/site.js
+++ b/js/site.js
@@ -97,8 +97,8 @@ $(document).ready(function (){
     });
 
     var twitchEmbedded = false;
-    // Countdown to November 1st @ 9:30AM PT 2025
-    $('div#countdown').countdown(1762014600000, {elapse: true})
+    // Countdown to November 7th @ 8:30AM PT 2026
+    $('div#countdown').countdown(1794069000000, {elapse: true})
         .on('update.countdown', function (event) {
             if (event.elapsed) {
                 if (event.offset.totalHours < 36) {
@@ -120,6 +120,6 @@ $(document).ready(function (){
         });
 
     // load donation bar
-    $('div#donation-bar').donateGoal(548692);
-    $('div#raised-top').currentRaised(548692);
+    $('div#donation-bar').donateGoal(565756);
+    $('div#raised-top').currentRaised(565756);
 });


### PR DESCRIPTION
### Motivation
- Correct the event duration and end date to reflect the 25-hour Nov 7–8, 2026 schedule.  
- Remove cents from the 2025 fundraising total for consistency with other years.  
- Ensure the countdown and donation widgets point to the updated event timestamp and Extra Life participant.  
- Keep the site fundraising goal up to date with the intended target.

### Description
- Updated `_posts/2000-01-04-when.md` to show the stream ends 25 hours later at 9:30am PT on November 8th.  
- Updated `_posts/2000-01-01-what.md` to change the advertised duration to `25 hours` and the 2025 total to `$26,724`.  
- Updated `_posts/2000-01-02-who.md` to add the 2025 bar to the fundraising chart, remove decimals, and adjust bar heights and aggregate total text.  
- Updated `js/site.js` to use the new countdown timestamp and Extra Life participant ID, and updated `_config.yml` to increase the site `goal` to `$25,000`.

### Testing
- Ran a local HTTP server with `python -m http.server` and it started successfully.  
- Captured a full-page screenshot using a Playwright script and the screenshot completed successfully.  
- Verified the modified files appear in the working tree and committed the changes with `git commit`.  
- No unit tests were applicable for these static content changes.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_695970632c888323a8685312f92e83b4)