### PR TITLE
Update displayed fundraising totals to reflect 2025 results

### DIFF
--- a/_posts/2000-01-01-what.md
+++ b/_posts/2000-01-01-what.md
@@ -23,7 +23,7 @@ style: center
 
 #### On **November 7th, 2026** I'll be running another charity event to raise money for the [**UCSF Benioff Children's Hospitals**](https://give.ucsfbenioffchildrens.org) via Extra-Life. I will be streaming on Twitch for **25 hours** playing games with friends, family, and **YOU.**
 
-#### Last year, you helped me raise over **$26,724** for the children through this event.  This year, more than ever, the children need our help.  Click the [**donate button**](https://stj.watch/donate) above and help us push past our **goal of {{ site.goal }}**.
+#### Last year, you helped me raise over **$28,783** for the children through this event.  This year, more than ever, the children need our help.  Click the [**donate button**](https://stj.watch/donate) above and help us push past our **goal of {{ site.goal }}**.
 
 #### If you're unable to donate, please [**watch the stream,**](https://stream.stj.watch/) say hello, chat, and encourage me when I'm **_completely exhausted_** near the 24 hour mark.
 

--- a/_posts/2000-01-02-who.md
+++ b/_posts/2000-01-02-who.md
@@ -35,7 +35,7 @@ fa-icon: user-astronaut
 
 --------------------------
 
-### Thanks to the incredible generosity of friends and family, my annual charity streams have raised **over $86,000 for children in need!**
+### Thanks to the incredible generosity of friends and family, my annual charity streams have raised **over $88,000 for children in need!**
 
 <div style="margin: 3em 0;"></div>
 
@@ -61,7 +61,7 @@ fa-icon: user-astronaut
         <span class="year">2024</span>
     </div>
     <div class="bar" style="height:100%">
-        <span class="amount">$26,724</span>
+        <span class="amount">$28,783</span>
         <span class="year">2025</span>
     </div>
 </div>


### PR DESCRIPTION
### Motivation
- Update the public-facing site content to reflect the latest fundraising totals from the 2025 event.

### Description
- Modified `/_posts/2000-01-01-what.md` and `/_posts/2000-01-02-who.md` to change the last-year total from `$26,724` to `$28,783` and the cumulative total from `over $86,000` to `over $88,000`, and updated the 2025 bar chart amount to `$28,783`.

### Testing
- No automated tests were run for this content-only change.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69e1d36befe0832391a01b6f96840845)